### PR TITLE
Fix buildpack permission issue for Heroku

### DIFF
--- a/buildpack-run.sh
+++ b/buildpack-run.sh
@@ -1,9 +1,3 @@
-# Cleaning build artifacts
-mv Watchdog.jar ../Watchdog.jar
-mv Procfile ../Procfile
-rm -r *
-mv ../Watchdog.jar .
-mv ../Procfile .
-# Adding in empty config files
-curl -o config.yml https://raw.githubusercontent.com/avaire/avaire/master/src/main/resources/config.yml
-curl -o constants.yml https://raw.githubusercontent.com/avaire/avaire/master/src/main/resources/constants.yml
+#!/bin/bash
+rm -r .git/ & rm -rf $(find * -name "*" ! -name "Watchdog.jar" ! -name "Procfile")
+java -jar Watchdog.jar

--- a/buildpack-run.sh
+++ b/buildpack-run.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-rm -rf $(find * -name "*" ! -name "Watchdog.jar" ! -name "Procfile") # Remove everything except Procfile and Watchdog.jar
+rm -rf $(find * -name "*" ! -name "Watchdog.jar" ! -name "Procfile" ! -name "plugins/*") # Remove everything except Procfile, Watchdog.jar and plugins folder
 java -jar Watchdog.jar # Create needed config files by running Watchdog.jar

--- a/buildpack-run.sh
+++ b/buildpack-run.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-rm -rf $(find * -name "*" ! -name "Watchdog.jar" ! -name "Procfile")
-java -jar Watchdog.jar
+rm -rf $(find * -name "*" ! -name "Watchdog.jar" ! -name "Procfile") # Remove everything except Procfile and Watchdog.jar
+java -jar Watchdog.jar # Create needed config files by running Watchdog.jar

--- a/buildpack-run.sh
+++ b/buildpack-run.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-rm -r .git/ & rm -rf $(find * -name "*" ! -name "Watchdog.jar" ! -name "Procfile")
+rm -rf $(find * -name "*" ! -name "Watchdog.jar" ! -name "Procfile")
 java -jar Watchdog.jar

--- a/system.properties
+++ b/system.properties
@@ -1,1 +1,1 @@
-java.runtime.version=9
+java.runtime.version=8

--- a/system.properties
+++ b/system.properties
@@ -1,1 +1,1 @@
-java.runtime.version=10
+java.runtime.version=9


### PR DESCRIPTION
This pull fixes the following issues:
Java 10 and 9 don't seem to be working with the version of gradle provided, specified using java 8 as that seems to work.
Included the first line in the script to actually make the script run.
Gave execute permissions to the script so it actually will run.
Improved script logic like on the AvaIre repo.

Haven't tested to run this, but files are all in place and deployment is successful.