### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# Build container
+
+FROM gradle:4.10.2-jdk11-slim AS build
+
+COPY --chown=gradle:gradle . /home/gradle/src
+WORKDIR /home/gradle/src
+RUN gradle build --no-daemon
+
+# Run container
+
+FROM openjdk:11-jre-slim AS runtime
+
+WORKDIR /opt/wdavaire/
+
+RUN adduser --disabled-password --gecos '' wdavaire; \
+    chown wdavaire:wdavaire -R /opt/wdavaire; \
+    chmod u+w /opt/wdavaire; \
+    chmod 0755 -R /opt/wdavaire
+
+USER wdavaire
+
+COPY --from=build /home/gradle/src/Watchdog.jar /bin/
+
+CMD ["java","-jar","/bin/Watchdog.jar","-env","--use-plugin-index"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+version: "3.7"
+services:
+    wdavaire:
+        image: wdavaire
+        build:
+            context: .
+        #container_name: wdavaire
+        depends_on:
+            - wdavairedb
+        restart: on-failure
+        environment:
+            - AVA_DATABASE_DATABASE=wdavaire
+            - AVA_DATABASE_HOSTNAME=wdavairedb
+            - AVA_DATABASE_USERNAME=wdavaire
+            - AVA_DATABASE_PASSWORD=wdavaire
+        volumes:
+            - C:\wdavaire:/opt/wdavaire
+    wdavairedb:
+        container_name: wdavairedb
+        image: mariadb
+        restart: on-failure
+        expose:
+            - "3306"
+        environment:
+            - MYSQL_DATABASE=wdavaire
+            - MYSQL_USER=wdavaire
+            - MYSQL_PASSWORD=wdavaire
+            - MYSQL_RANDOM_ROOT_PASSWORD=yes
+volumes:
+    wdavaire:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,9 @@
 version: "3.7"
 services:
     wdavaire:
-        image: wdavaire
         build:
             context: .
-        #container_name: wdavaire
+        container_name: wdavaire
         depends_on:
             - wdavairedb
         restart: on-failure


### PR DESCRIPTION
Firstly, thanks to the previous pulls: #68 #95 (see AvaIre repo) and Steve from Discord with helping me understand Docker(-Compose)!

This pull aims to bring full support for Docker for AvaIre. This includes composer and also docs to help each user on Mac/Win and Linux build their own instance of AvaIre with Docker!

The Website repo will recieve Docker support aswell when the conntection has been realised between the website/dashboard and AvaIre.

If any other parts of AvaIre would need support, just ask and i'll look at them aswell :-)

This pull already uses JDK11 for the runtime, as it seems to work fine and takes some work off from the #64 pull (see AvaIre repo).

Todo:
make docs for both watchdog and avaire so users know how to start.